### PR TITLE
Fix yakuhai related errors and typos in Spanish localization

### DIFF
--- a/i18n/es/yakus.po
+++ b/i18n/es/yakus.po
@@ -96,7 +96,7 @@ msgid "Robbing a Quad"
 msgstr "Robar el Poker"
 
 msgid "A concealed Quad can only be robbed to win Thirteen Orphans."
-msgstr "Un Poker oculto solo puede estar robado para ganae Trece Huérfanos."
+msgstr "Un Poker oculto solo puede estar robado para ganar Trece Huérfanos."
 
 msgid "Heavenly Hand"
 msgstr "Bendición del Cielo"
@@ -136,13 +136,13 @@ msgid "All Simples"
 msgstr "Todo Ordinario"
 
 msgid "Hand without Terminals or Honors."
-msgstr "Mano sin Terminales u Honores."
+msgstr "Mano sin Terminales ni Honores."
 
 msgid "Value Triplet"
 msgstr "Trío de Valor"
 
 msgid "Dragon, Player's Seat Wind or Round Wind Triplet."
-msgstr "Trío de un Dragón, del Viento de Jugadore o del Viento de Turno."
+msgstr "Trío de un Dragón, del Viento de Jugador o del Viento de Turno."
 
 msgid "Small Three Dragons"
 msgstr "Tres Pequeños Dragones"

--- a/src/sheets/templates/yakus.html
+++ b/src/sheets/templates/yakus.html
@@ -481,7 +481,7 @@
               <p class="yaku-description">__Dragon, Player's Seat Wind or Round Wind Triplet.__</p>
               <div class="yaku-score">
                 <div class="yaku-score-box">1</div>
-                <div class="yaku-score-box">2</div>
+                <div class="yaku-score-box">1</div>
               </div>
             </div>
             <div class="yaku-tiles">

--- a/src/sheets/templates/yakus.html
+++ b/src/sheets/templates/yakus.html
@@ -404,9 +404,9 @@
           <div class="tile-group">
             <div class="tile"><img src="__path.images__/tiles/haku.png"></div>
             <img src="__path.images__/yakus/arrow.svg">
-            <div class="tile"><img src="__path.images__/tiles/chun.png"></div>
-            <img src="__path.images__/yakus/arrow.svg">
             <div class="tile"><img src="__path.images__/tiles/hatsu.png"></div>
+            <img src="__path.images__/yakus/arrow.svg">
+            <div class="tile"><img src="__path.images__/tiles/chun.png"></div>
             <img src="__path.images__/yakus/arrow.svg">
             <div class="tile"><img src="__path.images__/tiles/haku.png"></div>
           </div>


### PR DESCRIPTION
I've been using your sheets since you posted them on reddit and the older version has been working flawlessly to teach new players. However recently a friend went to download your sheet and we found that the latest version has two errors that the older versions didn't have:
1. Yakuhai with closed hand gives 1 han, not 2
2. When haku is the dora indicator, the dora is hatsu, not chun.

I also noticed a few typos in the Spanish version which I fixed in this PR as well.