### PR TITLE
fix: Add fourth tile image to Kan

### DIFF
--- a/src/sheets/templates/initiation.html
+++ b/src/sheets/templates/initiation.html
@@ -201,6 +201,7 @@
               <div class="tile"><img src="__path.images__/tiles/sou-2.png"></div>
               <div class="tile"><img src="__path.images__/tiles/sou-2.png"></div>
               <div class="tile"><img src="__path.images__/tiles/sou-2.png"></div>
+              <div class="tile"><img src="__path.images__/tiles/sou-2.png"></div>
             </div>
             <div class="call-constraint">
               <img src="__path.images__/initiation/call-on.png">


### PR DESCRIPTION
Very small fix, the `initiation` page had only three tile images under the "Kan" heading